### PR TITLE
feat: modern dark theme for main screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -59,10 +59,10 @@ export default function App() {
             },
             headerShown: false, 
             tabBarStyle: {
-              backgroundColor: '#311b6b',
+              backgroundColor: '#000000',
             },
-            tabBarActiveTintColor: 'tomato',
-            tabBarInactiveTintColor: '#e4d0ff',
+            tabBarActiveTintColor: '#FFA500',
+            tabBarInactiveTintColor: '#888888',
           })}
         >
           <Tab.Screen name="To-Do" component={ToDo} />

--- a/components/Einstellungen.js
+++ b/components/Einstellungen.js
@@ -88,7 +88,7 @@ export default function Einstellungen() {
   };
 
   return (
-    <LinearGradient colors={['#85C1E9', '#311b6b']} style={styles.container}>
+    <LinearGradient colors={['#000000', '#1c1c1e']} style={styles.container}>
       <ScrollView>
         {/* Startseite */}
         <View style={styles.settingView}>
@@ -171,19 +171,19 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 20,
-    paddingTop: 40,
+    paddingTop: 60,
     width: '100%',
   },
   settingView: {
     marginBottom: 20,
     padding: 10,
-    backgroundColor: '#e4d0ff',
+    backgroundColor: '#2c2c2e',
     borderRadius: 6,
   },
   text: {
     fontSize: 18,
     marginBottom: 10,
-    color: '#1e085a',
+    color: '#f5f5f5',
     fontWeight: 'bold',
   },
   option: {
@@ -193,18 +193,19 @@ const styles = StyleSheet.create({
   },
   paragraph: {
     fontSize: 16,
+    color: '#f5f5f5',
   },
   checkbox: {
     marginRight: 10,
   },
   input: {
-    backgroundColor: '#ffffff',
-    borderColor: '#e4d0ff',
+    backgroundColor: '#1c1c1e',
+    borderColor: '#333',
     borderWidth: 1,
     borderRadius: 6,
     padding: 8,
     marginBottom: 10,
-    color: '#120438',
+    color: '#f5f5f5',
   },
   groupRow: {
     flexDirection: 'row',
@@ -220,6 +221,7 @@ const styles = StyleSheet.create({
   checkboxLabel: {
     marginLeft: 4,
     fontSize: 12,
+    color: '#f5f5f5',
   },
   deleteButton: {
     marginLeft: 4,

--- a/components/Tagebuch.js
+++ b/components/Tagebuch.js
@@ -125,7 +125,7 @@ export default function Tagebuch() {
   );
 
   return (
-    <LinearGradient colors={['#85C1E9', '#311b6b']} style={styles.main}>
+    <LinearGradient colors={['#000000', '#1c1c1e']} style={styles.main}>
       <View style={styles.contentview}>
         <FlatList
           data={entries}
@@ -170,24 +170,25 @@ const styles = StyleSheet.create({
   main: {
     flex: 1,
     padding: 20,
+    paddingTop: 60,
   },
   contentview: {
     flex: 1,
-    marginTop: 40,
   },
   entryCard: {
-    backgroundColor: '#e4d0ff',
+    backgroundColor: '#2c2c2e',
     padding: 16,
     borderRadius: 8,
     marginBottom: 12,
   },
   dateText: {
     fontSize: 16,
-    color: '#120438',
+    color: '#f5f5f5',
     fontWeight: 'bold',
   },
   buttonview: {
     padding: 16,
+    alignItems: 'center',
   },
   buttonPressable: {
     borderRadius: 10,
@@ -195,8 +196,10 @@ const styles = StyleSheet.create({
   },
   gradientButton: {
     paddingVertical: 15,
-    alignItems: 'center',
+    paddingHorizontal: 30,
     borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   buttonText: {
     color: 'white',
@@ -205,16 +208,18 @@ const styles = StyleSheet.create({
   },
   modalView: {
     flex: 1,
-    backgroundColor: '#311b6b',
+    backgroundColor: '#1c1c1e',
     padding: 20,
   },
   input: {
-    backgroundColor: '#e4d0ff',
-    color: '#120438',
+    backgroundColor: '#2c2c2e',
+    color: '#f5f5f5',
     borderRadius: 6,
     padding: 16,
     marginBottom: 20,
     flex: 1,
+    borderWidth: 1,
+    borderColor: '#333',
   },
   buttonContainer: {
     flexDirection: 'row',

--- a/components/To-Do.js
+++ b/components/To-Do.js
@@ -114,7 +114,7 @@ export default function ToDo() {
   };
 
   return (
-    <LinearGradient colors={['#85C1E9', '#311b6b']} style={styles.container}>
+    <LinearGradient colors={['#000000', '#1c1c1e']} style={styles.container}>
       <ScrollView style={{ flex: 1 }}>
         {groups
           .sort((a, b) => a.order - b.order)
@@ -211,7 +211,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 20,
-    paddingTop: 40,
+    paddingTop: 60,
     width: '100%',
   },
   groupSection: {
@@ -220,14 +220,14 @@ const styles = StyleSheet.create({
   groupTitle: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: 'white',
+    color: '#f5f5f5',
     marginBottom: 10,
     borderBottomWidth: 1,
-    borderColor: '#e4d0ff',
+    borderColor: '#333',
     paddingBottom: 4,
   },
   todoItem: {
-    backgroundColor: '#ffffffcc',
+    backgroundColor: '#2c2c2e',
     borderRadius: 8,
     padding: 12,
     marginBottom: 8,
@@ -238,10 +238,11 @@ const styles = StyleSheet.create({
   },
   todoText: {
     fontSize: 16,
-    color: '#120438',
+    color: '#f5f5f5',
   },
   buttonview: {
-    padding: 10,
+    padding: 16,
+    alignItems: 'center',
   },
   buttonPressable: {
     borderRadius: 10,
@@ -262,29 +263,29 @@ const styles = StyleSheet.create({
   modalView: {
     flex: 1,
     justifyContent: 'center',
-    backgroundColor: '#1e085a',
+    backgroundColor: '#1c1c1e',
     padding: 20,
   },
   input: {
     borderRadius: 6,
     borderWidth: 1,
-    borderColor: '#e4d0ff',
-    backgroundColor: '#e4d0ff',
-    color: '#120438',
+    borderColor: '#333',
+    backgroundColor: '#2c2c2e',
+    color: '#f5f5f5',
     padding: 16,
     marginBottom: 20,
   },
   pickerContainer: {
-    backgroundColor: '#e4d0ff',
+    backgroundColor: '#2c2c2e',
     borderRadius: 6,
     marginBottom: 20,
   },
   picker: {
     height: 50,
-    color: '#120438',
+    color: '#f5f5f5',
   },
   modalLabel: {
-    color: 'white',
+    color: '#f5f5f5',
     fontSize: 16,
     marginBottom: 6,
   },


### PR DESCRIPTION
## Summary
- restyle tab navigation and screens with a dark theme
- unify "Hinzufügen" button styles and alignment across Tagebuch and To-Do
- preserve light green for completed To-Do items

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1d2b1dfac832f8b01ed2fa131fab7