### PR TITLE
Unify add button and refine UI styling

### DIFF
--- a/components/AddButton.js
+++ b/components/AddButton.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Pressable, Text, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function AddButton({ onPress, title = 'Hinzufügen' }) {
+  return (
+    <Pressable onPress={onPress} style={styles.pressable}>
+      <LinearGradient colors={['#b180f0', '#6a0dad']} style={styles.gradient}>
+        <Text style={styles.text}>{title}</Text>
+      </LinearGradient>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  pressable: {
+    borderRadius: 10,
+    overflow: 'hidden',
+  },
+  gradient: {
+    paddingVertical: 15,
+    paddingHorizontal: 30,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    color: 'white',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+});

--- a/components/Einstellungen.js
+++ b/components/Einstellungen.js
@@ -170,6 +170,7 @@ export default function Einstellungen() {
           <TextInput
             style={styles.input}
             placeholder="Zielgewicht (kg)"
+            placeholderTextColor="#ccc"
             keyboardType="decimal-pad"
             value={goalWeight}
             onChangeText={saveGoalWeight}
@@ -177,6 +178,7 @@ export default function Einstellungen() {
           <TextInput
             style={styles.input}
             placeholder="Mindestschritte"
+            placeholderTextColor="#ccc"
             keyboardType="number-pad"
             value={minSteps}
             onChangeText={saveMinSteps}

--- a/components/Tagebuch.js
+++ b/components/Tagebuch.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { Text, Button, View, Modal, StyleSheet, TextInput, FlatList, Pressable, Alert } from 'react-native';
+import { Text, View, Modal, StyleSheet, TextInput, FlatList, Pressable, Alert } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LinearGradient } from 'expo-linear-gradient';
+import AddButton from './AddButton';
 
 export default function Tagebuch() {
   const [entries, setEntries] = useState([]);
@@ -118,7 +119,7 @@ export default function Tagebuch() {
     <Pressable
       onPress={() => editEntry(item.id)}
       onLongPress={() => deleteEntry(item.id)}
-      style={styles.entryCard}
+      style={styles.entry}
     >
       <Text style={styles.dateText}>{formatDate(item.date)}</Text>
     </Pressable>
@@ -131,15 +132,12 @@ export default function Tagebuch() {
           data={entries}
           renderItem={renderItem}
           keyExtractor={(item) => item.id}
+          contentContainerStyle={{ paddingBottom: 80 }}
         />
       </View>
 
       <View style={styles.buttonview}>
-        <Pressable onPress={handleNewEntry} style={styles.buttonPressable}>
-          <LinearGradient colors={['#FFD700', '#FFA500']} style={styles.gradientButton}>
-            <Text style={styles.buttonText}>Hinzufügen</Text>
-          </LinearGradient>
-        </Pressable>
+        <AddButton onPress={handleNewEntry} />
       </View>
 
       <Modal visible={modalVisible} animationType="slide" onRequestClose={() => setModalVisible(false)}>
@@ -147,18 +145,19 @@ export default function Tagebuch() {
           <TextInput
             style={styles.input}
             placeholder="Tagebucheintrag"
+            placeholderTextColor="#888"
             value={textInputValue}
             onChangeText={setTextInputValue}
             multiline
             numberOfLines={20}
           />
           <View style={styles.buttonContainer}>
-            <Button title="Abbrechen" color="#f31282" onPress={() => setModalVisible(false)} />
-            <Button
-              title={currentEntry ? 'Speichern' : 'Hinzufügen'}
-              color="#b180f0"
-              onPress={currentEntry ? saveEditedEntry : addEntry}
-            />
+            <Pressable onPress={() => setModalVisible(false)} style={styles.modalButton}>
+              <Text style={styles.modalButtonText}>Abbrechen</Text>
+            </Pressable>
+            <Pressable onPress={currentEntry ? saveEditedEntry : addEntry} style={styles.modalButton}>
+              <Text style={styles.modalButtonText}>Speichern</Text>
+            </Pressable>
           </View>
         </View>
       </Modal>
@@ -175,11 +174,10 @@ const styles = StyleSheet.create({
   contentview: {
     flex: 1,
   },
-  entryCard: {
-    backgroundColor: '#2c2c2e',
+  entry: {
     padding: 16,
-    borderRadius: 8,
-    marginBottom: 12,
+    borderBottomWidth: 1,
+    borderColor: '#333',
   },
   dateText: {
     fontSize: 16,
@@ -189,22 +187,6 @@ const styles = StyleSheet.create({
   buttonview: {
     padding: 16,
     alignItems: 'center',
-  },
-  buttonPressable: {
-    borderRadius: 10,
-    overflow: 'hidden',
-  },
-  gradientButton: {
-    paddingVertical: 15,
-    paddingHorizontal: 30,
-    borderRadius: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  buttonText: {
-    color: 'white',
-    fontSize: 18,
-    fontWeight: 'bold',
   },
   modalView: {
     flex: 1,
@@ -224,5 +206,17 @@ const styles = StyleSheet.create({
   buttonContainer: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+  },
+  modalButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    backgroundColor: '#b180f0',
+    borderRadius: 10,
+    margin: 5,
+  },
+  modalButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    textAlign: 'center',
   },
 });

--- a/components/To-Do.js
+++ b/components/To-Do.js
@@ -7,6 +7,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useFocusEffect } from '@react-navigation/native';
 import { Picker } from '@react-native-picker/picker';
+import AddButton from './AddButton';
 
 export default function ToDo() {
   const [modalVisible, setModalVisible] = useState(false);
@@ -150,14 +151,7 @@ export default function ToDo() {
       </ScrollView>
 
       <View style={styles.buttonview}>
-        <Pressable onPress={() => setModalVisible(true)} style={styles.buttonPressable}>
-          <LinearGradient
-            colors={['#FFD700', '#FFA500']}
-            style={styles.gradientButton}
-          >
-            <Text style={styles.buttonText}>Hinzufügen</Text>
-          </LinearGradient>
-        </Pressable>
+        <AddButton onPress={() => setModalVisible(true)} />
       </View>
 
       <Modal
@@ -170,6 +164,7 @@ export default function ToDo() {
           <TextInput
             style={styles.input}
             placeholder="Neuer To-Do-Punkt"
+            placeholderTextColor="#ccc"
             value={textInputValue}
             onChangeText={setTextInputValue}
           />
@@ -245,22 +240,6 @@ const styles = StyleSheet.create({
     padding: 16,
     alignItems: 'center',
   },
-  buttonPressable: {
-    borderRadius: 10,
-    overflow: 'hidden',
-  },
-  gradientButton: {
-    paddingVertical: 15,
-    paddingHorizontal: 30,
-    borderRadius: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  buttonText: {
-    color: 'white',
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
   modalView: {
     flex: 1,
     justifyContent: 'center',
@@ -281,15 +260,16 @@ const styles = StyleSheet.create({
     borderRadius: 6,
     marginBottom: 20,
     justifyContent: 'center',
+    height: 60,
   },
   picker: {
-    height: 50,
+    height: 60,
     color: '#f5f5f5',
     textAlign: 'center',
   },
   pickerItem: {
     color: '#f5f5f5',
-    fontSize: 18,
+    fontSize: 16,
     textAlign: 'center',
   },
   modalLabel: {

--- a/components/Tracking.js
+++ b/components/Tracking.js
@@ -4,6 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
+import AddButton from './AddButton';
 
 export default function Tracking() {
   const [entries, setEntries] = useState([]);
@@ -78,17 +79,16 @@ export default function Tracking() {
     setModalVisible(false);
   };
 
-  const deleteEntry = () => {
+  const deleteEntry = (date) => {
     Alert.alert('Eintrag löschen', 'Möchtest du diesen Eintrag wirklich löschen?', [
       { text: 'Abbrechen', style: 'cancel' },
       {
         text: 'Löschen',
         style: 'destructive',
         onPress: () => {
-          const filtered = entries.filter(e => e.date !== currentDate);
+          const filtered = entries.filter(e => e.date !== date);
           setEntries(filtered);
           saveEntries(filtered);
-          setModalVisible(false);
         }
       }
     ]);
@@ -98,7 +98,7 @@ export default function Tracking() {
     const weightMet = goalWeight && item.weight <= goalWeight;
     const stepsMet = minSteps && item.steps >= minSteps;
     return (
-      <Pressable onPress={() => openEditModal(item)} style={styles.entry}>
+      <Pressable onPress={() => openEditModal(item)} onLongPress={() => deleteEntry(item.date)} style={styles.entry}>
         <Text style={styles.dateText}>{new Date(item.date).toLocaleDateString('de-DE')}</Text>
         <View style={styles.valueRow}>
           <View style={[styles.valueBox, weightMet && styles.successBox]}>
@@ -126,11 +126,7 @@ export default function Tracking() {
         contentContainerStyle={{ paddingBottom: 80 }}
       />
       <View style={styles.addButtonView}>
-        <Pressable onPress={openAddModal} style={styles.addButton}>
-          <LinearGradient colors={['#b180f0', '#6a0dad']} style={styles.addButtonInner}>
-            <Text style={styles.addButtonText}>Hinzufügen</Text>
-          </LinearGradient>
-        </Pressable>
+        <AddButton onPress={openAddModal} />
       </View>
 
       <Modal
@@ -157,11 +153,6 @@ export default function Tracking() {
             <Pressable onPress={() => setModalVisible(false)} style={styles.modalButton}>
               <Text style={styles.modalButtonText}>Abbrechen</Text>
             </Pressable>
-            {entries.some(e => e.date === currentDate) && (
-              <Pressable onPress={deleteEntry} style={styles.modalButton}>
-                <Text style={styles.modalButtonText}>Löschen</Text>
-              </Pressable>
-            )}
             <Pressable onPress={saveEntry} style={styles.modalButton}>
               <Text style={styles.modalButtonText}>Speichern</Text>
             </Pressable>
@@ -211,22 +202,6 @@ const styles = StyleSheet.create({
   addButtonView: {
     padding: 16,
     alignItems: 'center',
-  },
-  addButton: {
-    borderRadius: 10,
-    overflow: 'hidden',
-  },
-  addButtonInner: {
-    paddingVertical: 15,
-    paddingHorizontal: 30,
-    borderRadius: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  addButtonText: {
-    color: 'white',
-    fontSize: 18,
-    fontWeight: 'bold',
   },
   modalView: {
     flex: 1,


### PR DESCRIPTION
## Summary
- Introduce reusable gradient AddButton component for consistent look
- Simplify tracking modal, enable long-press delete and match diary design to tracker
- Polish to-do and settings inputs with better colors and spacing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1daaa8100832f9476f7f868c93bad